### PR TITLE
fix

### DIFF
--- a/libs/logger-lib/src/lib/logger.module.ts
+++ b/libs/logger-lib/src/lib/logger.module.ts
@@ -4,7 +4,8 @@ import { CommonModule } from '@angular/common';
 import { LogMonitorComponent } from './log-monitor.component';
 import { LoggerConfig } from './logger.config';
 import { LoggerService } from './logger.service';
-import { DefaultLogFormatterService, LogFormatterService } from '..';
+import { DefaultLogFormatterService } from './default-log-formatter.service';
+import { LogFormatterService } from './log-formatter.service'; 
 
 // imports: [ LoggerModule.forRoot({ ... }) ]
 
@@ -20,9 +21,9 @@ const defaultFormatterConfig = [{
   declarations: [
     LogMonitorComponent
   ],
-  providers: [
-    LoggerService
-  ],
+  // providers: [
+  //   LoggerService
+  // ],
   exports: [
     LogMonitorComponent
   ]


### PR DESCRIPTION
- `providers: [LoggerService]` für LoggerService
kann man wieder kommentieren, weil das Service
eh das `@Injectable({providedIn: 'root'})` hat
- die import für defaultLogFormatter und
LogFormatter gingen auf die index.ts, sollten
aber direkt auf die Datei gehen.